### PR TITLE
Add controller API client interface (#1467)

### DIFF
--- a/cmd/fission-cli/app/app.go
+++ b/cmd/fission-cli/app/app.go
@@ -3,9 +3,12 @@ package app
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/fission/fission/pkg/controller/client"
+	"github.com/fission/fission/pkg/controller/client/rest"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	wrapper "github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/cobra"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/cobra/helptemplate"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/canaryconfig"
 	"github.com/fission/fission/pkg/fission-cli/cmd/environment"
 	"github.com/fission/fission/pkg/fission-cli/cmd/function"
@@ -20,6 +23,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/console"
 	"github.com/fission/fission/pkg/fission-cli/flag"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 const (
@@ -40,6 +44,13 @@ func App() *cobra.Command {
 		PersistentPreRunE: wrapper.Wrapper(
 			func(input cli.Input) error {
 				console.Verbosity = input.Int(flagkey.Verbosity)
+				serverUrl, err := util.GetServerURL(input)
+				if err != nil {
+					return err
+				}
+				restClient := rest.NewRESTClient(serverUrl)
+				// TODO: use fake rest client for offline spec generation
+				cmd.SetClientset(client.MakeClientset(restClient))
 				return nil
 			},
 		),

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -34,11 +34,13 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
 	"github.com/fission/fission/pkg/controller/client"
+	"github.com/fission/fission/pkg/controller/client/rest"
 	ferror "github.com/fission/fission/pkg/error"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 )
 
 var g struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func panicIf(err error) {
@@ -96,38 +98,38 @@ func TestFunctionApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.client.FunctionGet(&metav1.ObjectMeta{
+	_, err := g.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      testFunc.Metadata.Name,
 		Namespace: metav1.NamespaceDefault,
 	})
 	assertNotFoundFailure(err, "function")
 
-	m, err := g.client.FunctionCreate(testFunc)
+	m, err := g.Client().V1().Function().Create(testFunc)
 	panicIf(err)
 	defer func() {
-		err := g.client.FunctionDelete(m)
+		err := g.Client().V1().Function().Delete(m)
 		panicIf(err)
 	}()
 
-	_, err = g.client.FunctionCreate(testFunc)
+	_, err = g.Client().V1().Function().Create(testFunc)
 	assertNameReuseFailure(err, "function")
 
 	testFunc.Metadata.ResourceVersion = m.ResourceVersion
 	testFunc.Spec.Package.FunctionName = "yyy"
-	_, err = g.client.FunctionUpdate(testFunc)
+	_, err = g.Client().V1().Function().Update(testFunc)
 	panicIf(err)
 
 	testFunc.Metadata.ResourceVersion = ""
 	testFunc.Metadata.Name = "bar"
-	m2, err := g.client.FunctionCreate(testFunc)
+	m2, err := g.Client().V1().Function().Create(testFunc)
 	panicIf(err)
-	defer g.client.FunctionDelete(m2)
+	defer g.Client().V1().Function().Delete(m2)
 
-	funcs, err := g.client.FunctionList(metav1.NamespaceDefault)
+	funcs, err := g.Client().V1().Function().List(metav1.NamespaceDefault)
 	panicIf(err)
 	assert(len(funcs) == 2, fmt.Sprintf("created two functions, but found %v", len(funcs)))
 
-	funcs_url := g.client.Url + "/v2/functions"
+	funcs_url := g.Client().ServerURL() + "/v2/functions"
 	resp, err := http.Get(funcs_url)
 	panicIf(err)
 	defer resp.Body.Close()
@@ -157,20 +159,20 @@ func TestHTTPTriggerApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.client.HTTPTriggerGet(&metav1.ObjectMeta{
+	_, err := g.Client().V1().HTTPTrigger().Get(&metav1.ObjectMeta{
 		Name:      testTrigger.Metadata.Name,
 		Namespace: metav1.NamespaceDefault,
 	})
 	assertNotFoundFailure(err, "httptrigger")
 
-	m, err := g.client.HTTPTriggerCreate(testTrigger)
+	m, err := g.Client().V1().HTTPTrigger().Create(testTrigger)
 	panicIf(err)
-	defer g.client.HTTPTriggerDelete(m)
+	defer g.Client().V1().HTTPTrigger().Delete(m)
 
-	_, err = g.client.HTTPTriggerCreate(testTrigger)
+	_, err = g.Client().V1().HTTPTrigger().Create(testTrigger)
 	assertNameReuseFailure(err, "httptrigger")
 
-	tr, err := g.client.HTTPTriggerGet(m)
+	tr, err := g.Client().V1().HTTPTrigger().Get(m)
 	panicIf(err)
 	assert(testTrigger.Spec.Method == tr.Spec.Method &&
 		testTrigger.Spec.RelativeURL == tr.Spec.RelativeURL &&
@@ -179,20 +181,20 @@ func TestHTTPTriggerApi(t *testing.T) {
 
 	testTrigger.Metadata.ResourceVersion = m.ResourceVersion
 	testTrigger.Spec.RelativeURL = "/hi"
-	_, err = g.client.HTTPTriggerUpdate(testTrigger)
+	_, err = g.Client().V1().HTTPTrigger().Update(testTrigger)
 	panicIf(err)
 
 	testTrigger.Metadata.ResourceVersion = ""
 	testTrigger.Metadata.Name = "yyy"
-	_, err = g.client.HTTPTriggerCreate(testTrigger)
+	_, err = g.Client().V1().HTTPTrigger().Create(testTrigger)
 	assert(err != nil, "duplicate trigger should not be allowed")
 
 	testTrigger.Spec.RelativeURL = "/hi2"
-	m2, err := g.client.HTTPTriggerCreate(testTrigger)
+	m2, err := g.Client().V1().HTTPTrigger().Create(testTrigger)
 	panicIf(err)
-	defer g.client.HTTPTriggerDelete(m2)
+	defer g.Client().V1().HTTPTrigger().Delete(m2)
 
-	ts, err := g.client.HTTPTriggerList(metav1.NamespaceDefault)
+	ts, err := g.Client().V1().HTTPTrigger().List(metav1.NamespaceDefault)
 	panicIf(err)
 	assert(len(ts) == 2, fmt.Sprintf("created two triggers, but found %v", len(ts)))
 }
@@ -212,36 +214,36 @@ func TestEnvironmentApi(t *testing.T) {
 			Resources: v1.ResourceRequirements{},
 		},
 	}
-	_, err := g.client.EnvironmentGet(&metav1.ObjectMeta{
+	_, err := g.Client().V1().Environment().Get(&metav1.ObjectMeta{
 		Name:      testEnv.Metadata.Name,
 		Namespace: metav1.NamespaceDefault,
 	})
 	assertNotFoundFailure(err, "environment")
 
-	m, err := g.client.EnvironmentCreate(testEnv)
+	m, err := g.Client().V1().Environment().Create(testEnv)
 	panicIf(err)
-	defer g.client.EnvironmentDelete(m)
+	defer g.Client().V1().Environment().Delete(m)
 
-	_, err = g.client.EnvironmentCreate(testEnv)
+	_, err = g.Client().V1().Environment().Create(testEnv)
 	assertNameReuseFailure(err, "environment")
 
-	e, err := g.client.EnvironmentGet(m)
+	e, err := g.Client().V1().Environment().Get(m)
 	panicIf(err)
 	assert(reflect.DeepEqual(testEnv.Spec, e.Spec), "env should match after reading")
 
 	testEnv.Metadata.ResourceVersion = m.ResourceVersion
 	testEnv.Spec.Runtime.Image = "another-img"
-	_, err = g.client.EnvironmentUpdate(testEnv)
+	_, err = g.Client().V1().Environment().Update(testEnv)
 	panicIf(err)
 
 	testEnv.Metadata.ResourceVersion = ""
 	testEnv.Metadata.Name = "bar"
 
-	m2, err := g.client.EnvironmentCreate(testEnv)
+	m2, err := g.Client().V1().Environment().Create(testEnv)
 	panicIf(err)
-	defer g.client.EnvironmentDelete(m2)
+	defer g.Client().V1().Environment().Delete(m2)
 
-	ts, err := g.client.EnvironmentList(metav1.NamespaceDefault)
+	ts, err := g.Client().V1().Environment().List(metav1.NamespaceDefault)
 	panicIf(err)
 	assert(len(ts) == 2, fmt.Sprintf("created two envs, but found %v", len(ts)))
 }
@@ -261,20 +263,20 @@ func TestWatchApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.client.WatchGet(&metav1.ObjectMeta{
+	_, err := g.Client().V1().KubeWatcher().Get(&metav1.ObjectMeta{
 		Name:      testWatch.Metadata.Name,
 		Namespace: metav1.NamespaceDefault,
 	})
 	assertNotFoundFailure(err, "watch")
 
-	m, err := g.client.WatchCreate(testWatch)
+	m, err := g.Client().V1().KubeWatcher().Create(testWatch)
 	panicIf(err)
-	defer g.client.WatchDelete(m)
+	defer g.Client().V1().KubeWatcher().Delete(m)
 
-	_, err = g.client.WatchCreate(testWatch)
+	_, err = g.Client().V1().KubeWatcher().Create(testWatch)
 	assertNameReuseFailure(err, "watch")
 
-	w, err := g.client.WatchGet(m)
+	w, err := g.Client().V1().KubeWatcher().Get(m)
 	panicIf(err)
 	assert(testWatch.Spec.Namespace == w.Spec.Namespace &&
 		testWatch.Spec.Type == w.Spec.Type &&
@@ -282,11 +284,11 @@ func TestWatchApi(t *testing.T) {
 		testWatch.Spec.FunctionReference.Name == w.Spec.FunctionReference.Name, "watch should match after reading")
 
 	testWatch.Metadata.Name = "yyy"
-	m2, err := g.client.WatchCreate(testWatch)
+	m2, err := g.Client().V1().KubeWatcher().Create(testWatch)
 	panicIf(err)
-	defer g.client.WatchDelete(m2)
+	defer g.Client().V1().KubeWatcher().Delete(m2)
 
-	ws, err := g.client.WatchList(metav1.NamespaceDefault)
+	ws, err := g.Client().V1().KubeWatcher().List(metav1.NamespaceDefault)
 	panicIf(err)
 	assert(len(ws) == 2, fmt.Sprintf("created two watches, but found %v", len(ws)))
 }
@@ -305,17 +307,17 @@ func TestTimeTriggerApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.client.TimeTriggerGet(&metav1.ObjectMeta{Name: testTrigger.Metadata.Name})
+	_, err := g.Client().V1().TimeTrigger().Get(&metav1.ObjectMeta{Name: testTrigger.Metadata.Name})
 	assertNotFoundFailure(err, "trigger")
 
-	m, err := g.client.TimeTriggerCreate(testTrigger)
+	m, err := g.Client().V1().TimeTrigger().Create(testTrigger)
 	panicIf(err)
-	defer g.client.TimeTriggerDelete(m)
+	defer g.Client().V1().TimeTrigger().Delete(m)
 
-	_, err = g.client.TimeTriggerCreate(testTrigger)
+	_, err = g.Client().V1().TimeTrigger().Create(testTrigger)
 	assertNameReuseFailure(err, "trigger")
 
-	tr, err := g.client.TimeTriggerGet(m)
+	tr, err := g.Client().V1().TimeTrigger().Get(m)
 	panicIf(err)
 	assert(testTrigger.Spec.Cron == tr.Spec.Cron &&
 		testTrigger.Spec.FunctionReference.Type == tr.Spec.FunctionReference.Type &&
@@ -323,16 +325,16 @@ func TestTimeTriggerApi(t *testing.T) {
 
 	testTrigger.Metadata.ResourceVersion = m.ResourceVersion
 	testTrigger.Spec.Cron = "@hourly"
-	_, err = g.client.TimeTriggerUpdate(testTrigger)
+	_, err = g.Client().V1().TimeTrigger().Update(testTrigger)
 	panicIf(err)
 
 	testTrigger.Metadata.ResourceVersion = ""
 	testTrigger.Metadata.Name = "yyy"
 	testTrigger.Spec.Cron = "Not valid cron spec"
-	_, err = g.client.TimeTriggerCreate(testTrigger)
+	_, err = g.Client().V1().TimeTrigger().Create(testTrigger)
 	assertCronSpecFails(err)
 
-	ts, err := g.client.TimeTriggerList(metav1.NamespaceDefault)
+	ts, err := g.Client().V1().TimeTrigger().List(metav1.NamespaceDefault)
 	panicIf(err)
 	assert(len(ts) == 1, fmt.Sprintf("created two time triggers, but found %v", len(ts)))
 }
@@ -353,7 +355,10 @@ func TestMain(m *testing.M) {
 	go Start(logger, 8888, true)
 
 	time.Sleep(5 * time.Second)
-	g.client = client.MakeClient("http://localhost:8888")
+
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	// TODO: use fake rest client for offline spec generation
+	cmd.SetClientset(client.MakeClientset(restClient))
 
 	resp, err := http.Get("http://localhost:8888/")
 	panicIf(err)

--- a/pkg/controller/client/client.go
+++ b/pkg/controller/client/client.go
@@ -17,115 +17,33 @@ limitations under the License.
 package client
 
 import (
-	"bytes"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"strings"
-
-	"github.com/pkg/errors"
-
-	ferror "github.com/fission/fission/pkg/error"
-)
-
-var (
-	DefaultRequestHeaders map[string]string
+	"github.com/fission/fission/pkg/controller/client/rest"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	Client struct {
-		Url     string
-		Headers map[string]string
+	Interface interface {
+		V1() v1.V1Interface
+		ServerURL() string
+	}
+
+	Clientset struct {
+		restClient rest.Interface
+		v1         v1.V1Interface
 	}
 )
 
-func MakeClient(serverUrl string) *Client {
-	return &Client{
-		Url:     strings.TrimSuffix(serverUrl, "/"),
-		Headers: DefaultRequestHeaders,
+func MakeClientset(restClient rest.Interface) Interface {
+	return &Clientset{
+		restClient: restClient,
+		v1:         v1.MakeV1Client(restClient),
 	}
 }
 
-func (c *Client) create(relativeUrl string, contentType string, payload []byte) (*http.Response, error) {
-	var reader io.Reader
-	if len(payload) > 0 {
-		reader = bytes.NewReader(payload)
-	}
-	return c.sendRequest(http.MethodPost, c.v2CrdUrl(relativeUrl), map[string]string{"Content-type": contentType}, reader)
+func (c *Clientset) V1() v1.V1Interface {
+	return c.v1
 }
 
-func (c *Client) put(relativeUrl string, contentType string, payload []byte) (*http.Response, error) {
-	var reader io.Reader
-	if len(payload) > 0 {
-		reader = bytes.NewReader(payload)
-	}
-	return c.sendRequest(http.MethodPut, c.v2CrdUrl(relativeUrl), map[string]string{"Content-type": contentType}, reader)
-}
-
-func (c *Client) get(relativeUrl string) (*http.Response, error) {
-	return c.sendRequest(http.MethodGet, c.v2CrdUrl(relativeUrl), nil, nil)
-}
-
-func (c *Client) delete(relativeUrl string) error {
-	resp, err := c.sendRequest(http.MethodDelete, c.v2CrdUrl(relativeUrl), nil, nil)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return errors.Wrap(err, "error deleting")
-		} else {
-			return errors.Errorf("failed to delete: %v", string(body))
-		}
-	}
-
-	return nil
-}
-
-func (c *Client) proxy(method string, relativeUrl string, payload []byte) (*http.Response, error) {
-	var reader io.Reader
-	if len(payload) > 0 {
-		reader = bytes.NewReader(payload)
-	}
-	return c.sendRequest(method, c.proxyUrl(relativeUrl), nil, reader)
-}
-
-func (c *Client) sendRequest(method string, relativeUrl string, headers map[string]string, reader io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, relativeUrl, reader)
-	if err != nil {
-		return nil, err
-	}
-	for _, hs := range []map[string]string{headers, c.Headers} {
-		for k, v := range hs {
-			req.Header.Set(k, v)
-		}
-	}
-	return http.DefaultClient.Do(req)
-}
-
-func (c *Client) v2CrdUrl(relativeUrl string) string {
-	return c.Url + "/v2/" + strings.TrimPrefix(relativeUrl, "/")
-}
-
-func (c *Client) proxyUrl(relativeUrl string) string {
-	return c.Url + "/proxy/" + strings.TrimPrefix(relativeUrl, "/")
-}
-
-func (c *Client) handleResponse(resp *http.Response) ([]byte, error) {
-	if resp.StatusCode != 200 {
-		return nil, ferror.MakeErrorFromHTTP(resp)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	return body, err
-}
-
-func (c *Client) handleCreateResponse(resp *http.Response) ([]byte, error) {
-	if resp.StatusCode != 201 {
-		return nil, ferror.MakeErrorFromHTTP(resp)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	return body, err
+func (c *Clientset) ServerURL() string {
+	return c.restClient.ServerURL()
 }

--- a/pkg/controller/client/rest/client.go
+++ b/pkg/controller/client/rest/client.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2019 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+type (
+	Interface interface {
+		Create(relativeUrl string, contentType string, payload []byte) (*http.Response, error)
+		Put(relativeUrl string, contentType string, payload []byte) (*http.Response, error)
+		Get(relativeUrl string) (*http.Response, error)
+		Delete(relativeUrl string) error
+		Proxy(method string, relativeUrl string, payload []byte) (*http.Response, error)
+		ServerInfo() (*http.Response, error)
+		ServerURL() string
+	}
+
+	RESTClient struct {
+		url string
+	}
+)
+
+func NewRESTClient(serverUrl string) Interface {
+	return &RESTClient{
+		url: strings.TrimSuffix(serverUrl, "/"),
+	}
+}
+
+func (c *RESTClient) Create(relativeUrl string, contentType string, payload []byte) (*http.Response, error) {
+	var reader io.Reader
+	if len(payload) > 0 {
+		reader = bytes.NewReader(payload)
+	}
+	return c.sendRequest(http.MethodPost, c.v2CrdUrl(relativeUrl), map[string]string{"Content-type": contentType}, reader)
+}
+
+func (c *RESTClient) Put(relativeUrl string, contentType string, payload []byte) (*http.Response, error) {
+	var reader io.Reader
+	if len(payload) > 0 {
+		reader = bytes.NewReader(payload)
+	}
+	return c.sendRequest(http.MethodPut, c.v2CrdUrl(relativeUrl), map[string]string{"Content-type": contentType}, reader)
+}
+
+func (c *RESTClient) Get(relativeUrl string) (*http.Response, error) {
+	return c.sendRequest(http.MethodGet, c.v2CrdUrl(relativeUrl), nil, nil)
+}
+
+func (c *RESTClient) Delete(relativeUrl string) error {
+	resp, err := c.sendRequest(http.MethodDelete, c.v2CrdUrl(relativeUrl), nil, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "error deleting")
+		} else {
+			return errors.Errorf("failed to delete: %v", string(body))
+		}
+	}
+
+	return nil
+}
+
+func (c *RESTClient) Proxy(method string, relativeUrl string, payload []byte) (*http.Response, error) {
+	var reader io.Reader
+	if len(payload) > 0 {
+		reader = bytes.NewReader(payload)
+	}
+	return c.sendRequest(method, c.proxyUrl(relativeUrl), nil, reader)
+}
+
+func (c *RESTClient) ServerInfo() (*http.Response, error) {
+	return c.sendRequest(http.MethodGet, c.url, nil, nil)
+}
+
+func (c *RESTClient) ServerURL() string {
+	return c.url
+}
+
+func (c *RESTClient) sendRequest(method string, relativeUrl string, headers map[string]string, reader io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, relativeUrl, reader)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	// TODO: accept context
+	return ctxhttp.Do(context.Background(), &http.Client{}, req)
+}
+
+func (c *RESTClient) v2CrdUrl(relativeUrl string) string {
+	return c.url + "/v2/" + strings.TrimPrefix(relativeUrl, "/")
+}
+
+func (c *RESTClient) proxyUrl(relativeUrl string) string {
+	return c.url + "/proxy/" + strings.TrimPrefix(relativeUrl, "/")
+}

--- a/pkg/controller/client/v1/function.go
+++ b/pkg/controller/client/v1/function.go
@@ -14,23 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+package v1
 
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/fission-cli/console"
+	"github.com/fission/fission/pkg/controller/client/rest"
 )
 
-func (c *Client) FunctionCreate(f *fv1.Function) (*metav1.ObjectMeta, error) {
+type (
+	FunctionGetter interface {
+		Function() FunctionInterface
+	}
+
+	FunctionInterface interface {
+		Create(f *fv1.Function) (*metav1.ObjectMeta, error)
+		Get(m *metav1.ObjectMeta) (*fv1.Function, error)
+		GetRawDeployment(m *metav1.ObjectMeta) ([]byte, error)
+		Update(f *fv1.Function) (*metav1.ObjectMeta, error)
+		Delete(m *metav1.ObjectMeta) error
+		List(functionNamespace string) ([]fv1.Function, error)
+	}
+
+	Function struct {
+		client rest.Interface
+	}
+)
+
+func newFunctionClient(c *V1) FunctionInterface {
+	return &Function{client: c.restClient}
+}
+
+func (c *Function) Create(f *fv1.Function) (*metav1.ObjectMeta, error) {
 	err := f.Validate()
 	if err != nil {
 		return nil, fv1.AggregateValidationErrors("Function", err)
@@ -41,13 +60,13 @@ func (c *Client) FunctionCreate(f *fv1.Function) (*metav1.ObjectMeta, error) {
 		return nil, err
 	}
 
-	resp, err := c.create("functions", "application/json", reqbody)
+	resp, err := c.client.Create("functions", "application/json", reqbody)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleCreateResponse(resp)
+	body, err := handleCreateResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -61,17 +80,17 @@ func (c *Client) FunctionCreate(f *fv1.Function) (*metav1.ObjectMeta, error) {
 	return &m, nil
 }
 
-func (c *Client) FunctionGet(m *metav1.ObjectMeta) (*fv1.Function, error) {
+func (c *Function) Get(m *metav1.ObjectMeta) (*fv1.Function, error) {
 	relativeUrl := fmt.Sprintf("functions/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
 
-	resp, err := c.get(relativeUrl)
+	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -85,21 +104,21 @@ func (c *Client) FunctionGet(m *metav1.ObjectMeta) (*fv1.Function, error) {
 	return &f, nil
 }
 
-func (c *Client) FunctionGetRawDeployment(m *metav1.ObjectMeta) ([]byte, error) {
+func (c *Function) GetRawDeployment(m *metav1.ObjectMeta) ([]byte, error) {
 	relativeUrl := fmt.Sprintf("functions/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
 	relativeUrl += fmt.Sprintf("&deploymentraw=1")
 
-	resp, err := c.get(relativeUrl)
+	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	return c.handleResponse(resp)
+	return handleResponse(resp)
 }
 
-func (c *Client) FunctionUpdate(f *fv1.Function) (*metav1.ObjectMeta, error) {
+func (c *Function) Update(f *fv1.Function) (*metav1.ObjectMeta, error) {
 	err := f.Validate()
 	if err != nil {
 		return nil, fv1.AggregateValidationErrors("Function", err)
@@ -111,13 +130,13 @@ func (c *Client) FunctionUpdate(f *fv1.Function) (*metav1.ObjectMeta, error) {
 	}
 	relativeUrl := fmt.Sprintf("functions/%v", f.Metadata.Name)
 
-	resp, err := c.put(relativeUrl, "application/json", reqbody)
+	resp, err := c.client.Put(relativeUrl, "application/json", reqbody)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -130,21 +149,21 @@ func (c *Client) FunctionUpdate(f *fv1.Function) (*metav1.ObjectMeta, error) {
 	return &m, nil
 }
 
-func (c *Client) FunctionDelete(m *metav1.ObjectMeta) error {
+func (c *Function) Delete(m *metav1.ObjectMeta) error {
 	relativeUrl := fmt.Sprintf("functions/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
-	return c.delete(relativeUrl)
+	return c.client.Delete(relativeUrl)
 }
 
-func (c *Client) FunctionList(functionNamespace string) ([]fv1.Function, error) {
+func (c *Function) List(functionNamespace string) ([]fv1.Function, error) {
 	relativeUrl := fmt.Sprintf("functions?namespace=%v", functionNamespace)
-	resp, err := c.get(relativeUrl)
+	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -156,30 +175,4 @@ func (c *Client) FunctionList(functionNamespace string) ([]fv1.Function, error) 
 	}
 
 	return funcs, nil
-}
-
-func (c *Client) FunctionPodLogs(m *metav1.ObjectMeta) (io.ReadCloser, int, error) {
-	relativeUrl := fmt.Sprintf("functions/%v", m.Name)
-	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
-
-	queryURL, err := url.Parse(c.Url)
-	if err != nil {
-		return nil, 0, errors.Wrapf(err, "error parsing the base URL '%v'", c.Url)
-	}
-	queryURL.Path = fmt.Sprintf("/proxy/logs/%s", m.Name)
-
-	console.Verbose(2, fmt.Sprintf("Try to get pod logs from controller '%v'", queryURL.String()))
-
-	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "error creating logs request")
-	}
-
-	httpClient := http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "error executing get logs request")
-	}
-
-	return resp.Body, resp.StatusCode, nil
 }

--- a/pkg/controller/client/v1/httptrigger.go
+++ b/pkg/controller/client/v1/httptrigger.go
@@ -14,21 +14,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+package v1
 
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/fission/fission/pkg/controller/client/rest"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
 )
 
-func (c *Client) TimeTriggerCreate(t *fv1.TimeTrigger) (*metav1.ObjectMeta, error) {
+type (
+	HTTPTriggerGetter interface {
+		HTTPTrigger() HTTPTriggerInterface
+	}
+
+	HTTPTriggerInterface interface {
+		Create(t *fv1.HTTPTrigger) (*metav1.ObjectMeta, error)
+		Get(m *metav1.ObjectMeta) (*fv1.HTTPTrigger, error)
+		Update(t *fv1.HTTPTrigger) (*metav1.ObjectMeta, error)
+		Delete(m *metav1.ObjectMeta) error
+		List(triggerNamespace string) ([]fv1.HTTPTrigger, error)
+	}
+
+	HTTPTrigger struct {
+		client rest.Interface
+	}
+)
+
+func newHTTPTriggerClient(c *V1) HTTPTriggerInterface {
+	return &HTTPTrigger{client: c.restClient}
+}
+
+func (c *HTTPTrigger) Create(t *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
 	err := t.Validate()
 	if err != nil {
-		return nil, fv1.AggregateValidationErrors("TimeTrigger", err)
+		return nil, fv1.AggregateValidationErrors("HTTPTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(t)
@@ -36,13 +59,13 @@ func (c *Client) TimeTriggerCreate(t *fv1.TimeTrigger) (*metav1.ObjectMeta, erro
 		return nil, err
 	}
 
-	resp, err := c.create("triggers/time", "application/json", reqbody)
+	resp, err := c.client.Create("triggers/http", "application/json", reqbody)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleCreateResponse(resp)
+	body, err := handleCreateResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -56,22 +79,22 @@ func (c *Client) TimeTriggerCreate(t *fv1.TimeTrigger) (*metav1.ObjectMeta, erro
 	return &m, nil
 }
 
-func (c *Client) TimeTriggerGet(m *metav1.ObjectMeta) (*fv1.TimeTrigger, error) {
-	relativeUrl := fmt.Sprintf("triggers/time/%v", m.Name)
+func (c *HTTPTrigger) Get(m *metav1.ObjectMeta) (*fv1.HTTPTrigger, error) {
+	relativeUrl := fmt.Sprintf("triggers/http/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
 
-	resp, err := c.get(relativeUrl)
+	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
 
-	var t fv1.TimeTrigger
+	var t fv1.HTTPTrigger
 	err = json.Unmarshal(body, &t)
 	if err != nil {
 		return nil, err
@@ -80,25 +103,25 @@ func (c *Client) TimeTriggerGet(m *metav1.ObjectMeta) (*fv1.TimeTrigger, error) 
 	return &t, nil
 }
 
-func (c *Client) TimeTriggerUpdate(t *fv1.TimeTrigger) (*metav1.ObjectMeta, error) {
+func (c *HTTPTrigger) Update(t *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
 	err := t.Validate()
 	if err != nil {
-		return nil, fv1.AggregateValidationErrors("TimeTrigger", err)
+		return nil, fv1.AggregateValidationErrors("HTTPTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(t)
 	if err != nil {
 		return nil, err
 	}
-	relativeUrl := fmt.Sprintf("triggers/time/%v", t.Metadata.Name)
+	relativeUrl := fmt.Sprintf("triggers/http/%v", t.Metadata.Name)
 
-	resp, err := c.put(relativeUrl, "application/json", reqbody)
+	resp, err := c.client.Put(relativeUrl, "application/json", reqbody)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -111,26 +134,26 @@ func (c *Client) TimeTriggerUpdate(t *fv1.TimeTrigger) (*metav1.ObjectMeta, erro
 	return &m, nil
 }
 
-func (c *Client) TimeTriggerDelete(m *metav1.ObjectMeta) error {
-	relativeUrl := fmt.Sprintf("triggers/time/%v", m.Name)
+func (c *HTTPTrigger) Delete(m *metav1.ObjectMeta) error {
+	relativeUrl := fmt.Sprintf("triggers/http/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
-	return c.delete(relativeUrl)
+	return c.client.Delete(relativeUrl)
 }
 
-func (c *Client) TimeTriggerList(ns string) ([]fv1.TimeTrigger, error) {
-	relativeUrl := fmt.Sprintf("triggers/time?namespace=%v", ns)
-	resp, err := c.get(relativeUrl)
+func (c *HTTPTrigger) List(triggerNamespace string) ([]fv1.HTTPTrigger, error) {
+	relativeUrl := fmt.Sprintf("triggers/http?namespace=%v", triggerNamespace)
+	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
 
-	triggers := make([]fv1.TimeTrigger, 0)
+	triggers := make([]fv1.HTTPTrigger, 0)
 	err = json.Unmarshal(body, &triggers)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/client/v1/misc.go
+++ b/pkg/controller/client/v1/misc.go
@@ -14,35 +14,58 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+package v1
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context/ctxhttp"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission/pkg/controller/client/rest"
+	"github.com/fission/fission/pkg/fission-cli/console"
 	"github.com/fission/fission/pkg/info"
 )
 
-func (c *Client) SecretGet(m *metav1.ObjectMeta) (*apiv1.Secret, error) {
+// TODO: we should remove this interface, having this for now is for backward compatibility.
+type (
+	MiscGetter interface {
+		Misc() MiscInterface
+	}
+
+	MiscInterface interface {
+		SecretGet(m *metav1.ObjectMeta) (*apiv1.Secret, error)
+		ConfigMapGet(m *metav1.ObjectMeta) (*apiv1.ConfigMap, error)
+		GetSvcURL(label string) (string, error)
+		ServerInfo() (*info.ServerInfo, error)
+		PodLogs(m *metav1.ObjectMeta) (io.ReadCloser, int, error)
+	}
+
+	Misc struct {
+		client rest.Interface
+	}
+)
+
+func newMiscClient(c *V1) MiscInterface {
+	return &Misc{client: c.restClient}
+}
+
+func (c *Misc) SecretGet(m *metav1.ObjectMeta) (*apiv1.Secret, error) {
 	relativeUrl := fmt.Sprintf("secrets/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
 
-	resp, err := c.get(relativeUrl)
+	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -56,17 +79,17 @@ func (c *Client) SecretGet(m *metav1.ObjectMeta) (*apiv1.Secret, error) {
 	return &secret, nil
 }
 
-func (c *Client) ConfigMapGet(m *metav1.ObjectMeta) (*apiv1.ConfigMap, error) {
+func (c *Misc) ConfigMapGet(m *metav1.ObjectMeta) (*apiv1.ConfigMap, error) {
 	relativeUrl := fmt.Sprintf("configmaps/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
 
-	resp, err := c.get(relativeUrl)
+	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := handleResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +103,8 @@ func (c *Client) ConfigMapGet(m *metav1.ObjectMeta) (*apiv1.ConfigMap, error) {
 	return &configMap, nil
 }
 
-func (c *Client) GetSvcURL(label string) (string, error) {
-	resp, err := c.proxy(http.MethodGet, "svcname?"+label, nil)
+func (c *Misc) GetSvcURL(label string) (string, error) {
+	resp, err := c.client.Proxy(http.MethodGet, "svcname?"+label, nil)
 	if err != nil {
 		return "", err
 	}
@@ -100,11 +123,8 @@ func (c *Client) GetSvcURL(label string) (string, error) {
 	return storageSvc, err
 }
 
-func (c *Client) ServerInfo() (*info.ServerInfo, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	resp, err := ctxhttp.Get(ctx, &http.Client{}, c.Url)
+func (c *Misc) ServerInfo() (*info.ServerInfo, error) {
+	resp, err := c.client.ServerInfo()
 	if err != nil {
 		return nil, err
 	}
@@ -122,4 +142,14 @@ func (c *Client) ServerInfo() (*info.ServerInfo, error) {
 	}
 
 	return info, nil
+}
+
+func (c *Misc) PodLogs(m *metav1.ObjectMeta) (io.ReadCloser, int, error) {
+	uri := fmt.Sprintf("logs/%s", m.Name)
+	console.Verbose(2, fmt.Sprintf("Try to get pod logs from controller '%v'", uri))
+	resp, err := c.client.Proxy(http.MethodPost, uri, nil)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "error executing get logs request")
+	}
+	return resp.Body, resp.StatusCode, nil
 }

--- a/pkg/controller/client/v1/v1.go
+++ b/pkg/controller/client/v1/v1.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	ferror "github.com/fission/fission/pkg/error"
+
+	"github.com/fission/fission/pkg/controller/client/rest"
+)
+
+type (
+	V1Interface interface {
+		MiscGetter
+		CanaryConfigGetter
+		EnvironmentGetter
+		FunctionGetter
+		HTTPTriggerGetter
+		KubeWatcherGetter
+		MessageQueueTriggerGetter
+		PackageGetter
+		TimeTriggerGetter
+	}
+
+	V1 struct {
+		restClient rest.Interface
+	}
+)
+
+func MakeV1Client(restClient rest.Interface) *V1 {
+	return &V1{restClient: restClient}
+}
+
+func (c *V1) Misc() MiscInterface {
+	return newMiscClient(c)
+}
+
+func (c *V1) CanaryConfig() CanaryConfigInterface {
+	return newCanaryConfigClient(c)
+}
+
+func (c *V1) Environment() EnvironmentInterface {
+	return newEnvironmentClient(c)
+}
+
+func (c *V1) Function() FunctionInterface {
+	return newFunctionClient(c)
+}
+
+func (c *V1) HTTPTrigger() HTTPTriggerInterface {
+	return newHTTPTriggerClient(c)
+}
+
+func (c *V1) KubeWatcher() KubeWatcherInterface {
+	return newKubeWatcher(c)
+}
+
+func (c *V1) MessageQueueTrigger() MessageQueueTriggerInterface {
+	return newMessageQueueTrigger(c)
+}
+
+func (c *V1) Package() PackageInterface {
+	return newPackageClient(c)
+}
+
+func (c *V1) TimeTrigger() TimeTriggerInterface {
+	return newTimeTriggerClient(c)
+}
+
+func handleResponse(resp *http.Response) ([]byte, error) {
+	if resp.StatusCode != 200 {
+		return nil, ferror.MakeErrorFromHTTP(resp)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	return body, err
+}
+
+func handleCreateResponse(resp *http.Response) ([]byte, error) {
+	if resp.StatusCode != 201 {
+		return nil, ferror.MakeErrorFromHTTP(resp)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	return body, err
+}

--- a/pkg/fission-cli/cmd/canaryconfig/create.go
+++ b/pkg/fission-cli/cmd/canaryconfig/create.go
@@ -24,27 +24,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/types"
 )
 
 type CreateSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 	canary *fv1.CanaryConfig
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -74,7 +67,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 
 	// check that the trigger exists in the same namespace.
-	htTrigger, err := opts.client.HTTPTriggerGet(&metav1.ObjectMeta{
+	htTrigger, err := opts.Client().V1().HTTPTrigger().Get(&metav1.ObjectMeta{
 		Name:      ht,
 		Namespace: fnNs,
 	})
@@ -100,7 +93,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 	// check that the functions exist in the same namespace
 	fnList := []string{newFunc, oldFunc}
-	err = util.CheckFunctionExistence(opts.client, fnList, fnNs)
+	err = util.CheckFunctionExistence(opts.Client(), fnList, fnNs)
 	if err != nil {
 		return errors.Wrap(err, "error checking functions existence")
 	}
@@ -129,7 +122,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	_, err := opts.client.CanaryConfigCreate(opts.canary)
+	_, err := opts.Client().V1().CanaryConfig().Create(opts.canary)
 	if err != nil {
 		return errors.Wrap(err, "error creating canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/delete.go
+++ b/pkg/fission-cli/cmd/canaryconfig/delete.go
@@ -22,25 +22,17 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.run(input)
+	return (&DeleteSubCommand{}).run(input)
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) error {
@@ -49,7 +41,7 @@ func (opts *DeleteSubCommand) run(input cli.Input) error {
 		Namespace: input.String(flagkey.NamespaceCanary),
 	}
 
-	err := opts.client.CanaryConfigDelete(m)
+	err := opts.Client().V1().CanaryConfig().Delete(m)
 	if err != nil {
 		return errors.Wrap(err, "error deleting canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -24,29 +24,21 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Get(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := GetSubCommand{
-		client: c,
-	}
-	return opts.run(input)
+	return (&GetSubCommand{}).run(input)
 }
 
 func (opts *GetSubCommand) run(input cli.Input) error {
-	canaryCfg, err := opts.client.CanaryConfigGet(&metav1.ObjectMeta{
+	canaryCfg, err := opts.Client().V1().CanaryConfig().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.CanaryName),
 		Namespace: input.String(flagkey.NamespaceCanary),
 	})

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -23,26 +23,18 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
-	client    *client.Client
+	cmd.CommandActioner
 	namespace string
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
@@ -59,7 +51,7 @@ func (opts *ListSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) error {
-	canaryCfgs, err := opts.client.CanaryConfigList(opts.namespace)
+	canaryCfgs, err := opts.Client().V1().CanaryConfig().List(opts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "error listing canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -24,26 +24,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 	canary *fv1.CanaryConfig
 }
 
 func Update(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := UpdateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&UpdateSubCommand{}).do(input)
 }
 
 func (opts *UpdateSubCommand) do(input cli.Input) error {
@@ -68,7 +60,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 		return errors.Wrap(err, "error parsing time duration")
 	}
 
-	canaryCfg, err := opts.client.CanaryConfigGet(&metav1.ObjectMeta{
+	canaryCfg, err := opts.Client().V1().CanaryConfig().Get(&metav1.ObjectMeta{
 		Name:      name,
 		Namespace: ns,
 	})
@@ -100,7 +92,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.client.CanaryConfigUpdate(opts.canary)
+	_, err := opts.Client().V1().CanaryConfig().Update(opts.canary)
 	if err != nil {
 		return errors.Wrap(err, "error updating canary config")
 	}

--- a/pkg/fission-cli/cmd/cmd.go
+++ b/pkg/fission-cli/cmd/cmd.go
@@ -17,9 +17,28 @@ limitations under the License.
 package cmd
 
 import (
+	"sync"
+
+	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 )
 
 type (
-	CommandAction func(input cli.Input) error
+	CommandAction   func(input cli.Input) error
+	CommandActioner struct{}
 )
+
+var (
+	once             = sync.Once{}
+	defaultClientset client.Interface
+)
+
+func SetClientset(clientset client.Interface) {
+	once.Do(func() {
+		defaultClientset = clientset
+	})
+}
+
+func (c *CommandActioner) Client() client.Interface {
+	return defaultClientset
+}

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -24,8 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -34,19 +34,12 @@ import (
 )
 
 type CreateSubCommand struct {
-	client *client.Client
-	env    *fv1.Environment
+	cmd.CommandActioner
+	env *fv1.Environment
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -72,7 +65,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 func (opts *CreateSubCommand) run(input cli.Input) error {
 	m := opts.env.Metadata
 
-	envList, err := opts.client.EnvironmentList(m.Namespace)
+	envList, err := opts.Client().V1().Environment().List(m.Namespace)
 	if err != nil {
 		return err
 	} else if len(envList) > 0 {
@@ -92,7 +85,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err = opts.client.EnvironmentCreate(opts.env)
+	_, err = opts.Client().V1().Environment().Create(opts.env)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -22,25 +22,17 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DeleteSubCommand{}).do(input)
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
@@ -49,7 +41,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 		Namespace: input.String(flagkey.NamespaceEnvironment),
 	}
 
-	err := opts.client.EnvironmentDelete(m)
+	err := opts.Client().V1().Environment().Delete(m)
 	if err != nil {
 		return errors.Wrap(err, "error deleting environment")
 	}

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -24,25 +24,17 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Get(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := GetSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&GetSubCommand{}).do(input)
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
@@ -51,7 +43,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 		Namespace: input.String(flagkey.NamespaceEnvironment),
 	}
 
-	env, err := opts.client.EnvironmentGet(m)
+	env, err := opts.Client().V1().Environment().Get(m)
 	if err != nil {
 		return errors.Wrap(err, "error getting environment")
 	}

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -23,29 +23,21 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	envs, err := opts.client.EnvironmentList(input.String(flagkey.NamespaceEnvironment))
+	envs, err := opts.Client().V1().Environment().List(input.String(flagkey.NamespaceEnvironment))
 	if err != nil {
 		return errors.Wrap(err, "error listing environments")
 	}

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -24,27 +24,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
 type UpdateSubCommand struct {
-	client *client.Client
-	env    *fv1.Environment
+	cmd.CommandActioner
+	env *fv1.Environment
 }
 
 func Update(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := UpdateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&UpdateSubCommand{}).do(input)
 }
 
 func (opts *UpdateSubCommand) do(input cli.Input) error {
@@ -56,7 +48,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
-	env, err := opts.client.EnvironmentGet(&metav1.ObjectMeta{
+	env, err := opts.Client().V1().Environment().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
 		Namespace: input.String(flagkey.NamespaceEnvironment),
 	})
@@ -74,7 +66,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.client.EnvironmentUpdate(opts.env)
+	_, err := opts.Client().V1().Environment().Update(opts.env)
 	if err != nil {
 		return errors.Wrap(err, "error updating environment")
 	}

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -27,9 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/httptrigger"
 	_package "github.com/fission/fission/pkg/fission-cli/cmd/package"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
@@ -44,20 +44,13 @@ const (
 )
 
 type CreateSubCommand struct {
-	client   *client.Client
+	cmd.CommandActioner
 	function *fv1.Function
 	specFile string
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -83,7 +76,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 	if !toSpec {
 		// check for unique function names within a namespace
-		fn, err := opts.client.FunctionGet(&metav1.ObjectMeta{
+		fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 			Name:      input.String(flagkey.FnName),
 			Namespace: input.String(flagkey.NamespaceFunction),
 		})
@@ -139,7 +132,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			pkgMetadata = &pkg.Metadata
 		} else {
 			// use existing package
-			pkg, err = opts.client.PackageGet(&metav1.ObjectMeta{
+			pkg, err = opts.Client().V1().Package().Get(&metav1.ObjectMeta{
 				Namespace: fnNamespace,
 				Name:      pkgName,
 			})
@@ -181,7 +174,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 					fnName, envName))
 			}
 		} else {
-			_, err := opts.client.EnvironmentGet(&metav1.ObjectMeta{
+			_, err := opts.Client().V1().Environment().Get(&metav1.ObjectMeta{
 				Namespace: envNamespace,
 				Name:      envName,
 			})
@@ -213,7 +206,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		pkgName := fmt.Sprintf("%v-%v", fnName, uuid.NewV4().String())
 
 		// create new package in the same namespace as the function.
-		pkgMetadata, err = _package.CreatePackage(input, opts.client, pkgName, fnNamespace, envName, envNamespace,
+		pkgMetadata, err = _package.CreatePackage(input, opts.Client(), pkgName, fnNamespace, envName, envNamespace,
 			srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, opts.specFile, noZip)
 		if err != nil {
 			return errors.Wrap(err, "error creating package")
@@ -227,7 +220,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		// check the referenced secret is in the same ns as the function, if not give a warning.
 		if !toSpec { // TODO: workaround in order not to block users from creating function spec, remove it.
 			for _, secretName := range secretNames {
-				_, err := opts.client.SecretGet(&metav1.ObjectMeta{
+				_, err := opts.Client().V1().Misc().SecretGet(&metav1.ObjectMeta{
 					Namespace: fnNamespace,
 					Name:      secretName,
 				})
@@ -253,7 +246,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		// check the referenced cfgmap is in the same ns as the function, if not give a warning.
 		if !toSpec {
 			for _, cfgMapName := range cfgMapNames {
-				_, err := opts.client.ConfigMapGet(&metav1.ObjectMeta{
+				_, err := opts.Client().V1().Misc().ConfigMapGet(&metav1.ObjectMeta{
 					Namespace: fnNamespace,
 					Name:      cfgMapName,
 				})
@@ -316,7 +309,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.client.FunctionCreate(opts.function)
+	_, err := opts.Client().V1().Function().Create(opts.function)
 	if err != nil {
 		return errors.Wrap(err, "error creating function")
 	}
@@ -352,7 +345,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 			},
 		},
 	}
-	_, err = opts.client.HTTPTriggerCreate(ht)
+	_, err = opts.Client().V1().HTTPTrigger().Create(ht)
 	if err != nil {
 		return errors.Wrap(err, "error creating HTTP trigger")
 	}

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -22,25 +22,17 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DeleteSubCommand{}).do(input)
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
@@ -49,7 +41,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 		Namespace: input.String(flagkey.NamespaceFunction),
 	}
 
-	err := opts.client.FunctionDelete(m)
+	err := opts.Client().V1().Function().Delete(m)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("delete function '%v'", m.Name))
 	}

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -22,29 +22,21 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Get(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := GetSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&GetSubCommand{}).do(input)
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
-	fn, err := opts.client.FunctionGet(&metav1.ObjectMeta{
+	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
 		Namespace: input.String(flagkey.NamespaceFunction),
 	})
@@ -52,7 +44,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 		return errors.Wrap(err, "error getting function")
 	}
 
-	pkg, err := opts.client.PackageGet(&metav1.ObjectMeta{
+	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
 		Name:      fn.Spec.Package.PackageRef.Name,
 		Namespace: fn.Spec.Package.PackageRef.Namespace,
 	})

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -24,29 +24,21 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetMetaSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func GetMeta(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := GetMetaSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&GetMetaSubCommand{}).do(input)
 }
 
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
-	fn, err := opts.client.FunctionGet(&metav1.ObjectMeta{
+	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
 		Namespace: input.String(flagkey.NamespaceFunction),
 	})

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -24,31 +24,23 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
 	ns := input.String(flagkey.NamespaceFunction)
 
-	fns, err := opts.client.FunctionList(ns)
+	fns, err := opts.Client().V1().Function().List(ns)
 	if err != nil {
 		return errors.Wrap(err, "error listing functions")
 	}

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -24,26 +24,19 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/logdb"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type LogSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Log(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := LogSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&LogSubCommand{}).do(input)
 }
 
 func (opts *LogSubCommand) do(input cli.Input) error {
@@ -57,7 +50,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 		recordLimit = 1000
 	}
 
-	f, err := opts.client.FunctionGet(&metav1.ObjectMeta{
+	f, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
 		Namespace: input.String(flagkey.NamespaceFunction),
 	})

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -26,9 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -36,19 +36,12 @@ import (
 )
 
 type CreateSubCommand struct {
-	client  *client.Client
+	cmd.CommandActioner
 	trigger *fv1.HTTPTrigger
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -85,7 +78,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		Namespace: fnNamespace,
 	}
 
-	htTrigger, err := opts.client.HTTPTriggerGet(m)
+	htTrigger, err := opts.Client().V1().HTTPTrigger().Get(m)
 	if err != nil && !ferror.IsNotFound(err) {
 		return err
 	}
@@ -128,7 +121,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			}
 		}
 	} else {
-		err = util.CheckFunctionExistence(opts.client, functionList, fnNamespace)
+		err = util.CheckFunctionExistence(opts.Client(), functionList, fnNamespace)
 		if err != nil {
 			console.Warn(err.Error())
 		}
@@ -173,7 +166,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.client.HTTPTriggerCreate(opts.trigger)
+	_, err := opts.Client().V1().HTTPTrigger().Create(opts.trigger)
 	if err != nil {
 		return errors.Wrap(err, "create HTTP trigger")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/delete.go
+++ b/pkg/fission-cli/cmd/httptrigger/delete.go
@@ -23,29 +23,21 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
 type DeleteSubCommand struct {
-	client       *client.Client
+	cmd.CommandActioner
 	triggerName  string
 	functionName string
 	namespace    string
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DeleteSubCommand{}).do(input)
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
@@ -69,7 +61,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) error {
-	triggers, err := opts.client.HTTPTriggerList(opts.namespace)
+	triggers, err := opts.Client().V1().HTTPTrigger().List(opts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "error getting HTTP trigger list")
 	}
@@ -90,7 +82,7 @@ func (opts *DeleteSubCommand) run(input cli.Input) error {
 	errs := utils.MultiErrorWithFormat()
 
 	for _, name := range triggersToDelete {
-		err := opts.client.HTTPTriggerDelete(&metav1.ObjectMeta{
+		err := opts.Client().V1().HTTPTrigger().Delete(&metav1.ObjectMeta{
 			Name:      name,
 			Namespace: opts.namespace,
 		})

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -26,25 +26,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Get(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := GetSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&GetSubCommand{}).do(input)
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
@@ -56,7 +48,7 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 		Name:      input.String(flagkey.HtName),
 		Namespace: input.String(flagkey.NamespaceFunction),
 	}
-	ht, err := opts.client.HTTPTriggerGet(m)
+	ht, err := opts.Client().V1().HTTPTrigger().Get(m)
 	if err != nil {
 		return errors.Wrap(err, "error getting http trigger")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -20,25 +20,17 @@ import (
 	"github.com/pkg/errors"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
@@ -46,7 +38,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) error {
-	hts, err := opts.client.HTTPTriggerList(input.String(flagkey.NamespaceTrigger))
+	hts, err := opts.Client().V1().HTTPTrigger().List(input.String(flagkey.NamespaceTrigger))
 	if err != nil {
 		return errors.Wrap(err, "error listing HTTP triggers")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -23,27 +23,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
-	client  *client.Client
+	cmd.CommandActioner
 	trigger *fv1.HTTPTrigger
 }
 
 func Update(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := UpdateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&UpdateSubCommand{}).do(input)
 }
 
 func (opts *UpdateSubCommand) do(input cli.Input) error {
@@ -58,7 +51,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	htName := input.String(flagkey.HtName)
 	triggerNamespace := input.String(flagkey.NamespaceTrigger)
 
-	ht, err := opts.client.HTTPTriggerGet(&metav1.ObjectMeta{
+	ht, err := opts.Client().V1().HTTPTrigger().Get(&metav1.ObjectMeta{
 		Name:      htName,
 		Namespace: triggerNamespace,
 	})
@@ -77,7 +70,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	if input.IsSet(flagkey.HtFnName) {
 		// get the functions and their weights if specified
 		functionList := input.StringSlice(flagkey.HtFnName)
-		err := util.CheckFunctionExistence(opts.client, functionList, triggerNamespace)
+		err := util.CheckFunctionExistence(opts.Client(), functionList, triggerNamespace)
 		if err != nil {
 			console.Warn(err.Error())
 		}
@@ -120,7 +113,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.client.HTTPTriggerUpdate(opts.trigger)
+	_, err := opts.Client().V1().HTTPTrigger().Update(opts.trigger)
 	if err != nil {
 		return errors.Wrap(err, "error updating the HTTP trigger")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -24,8 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -33,19 +33,12 @@ import (
 )
 
 type CreateSubCommand struct {
-	client  *client.Client
+	cmd.CommandActioner
 	watcher *fv1.KubernetesWatchTrigger
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -119,7 +112,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.client.WatchCreate(opts.watcher)
+	_, err := opts.Client().V1().KubeWatcher().Create(opts.watcher)
 	if err != nil {
 		return errors.Wrap(err, "error creating kubewatch")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/delete.go
+++ b/pkg/fission-cli/cmd/kubewatch/delete.go
@@ -22,27 +22,19 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
-	client    *client.Client
+	cmd.CommandActioner
 	name      string
 	namespace string
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DeleteSubCommand{}).do(input)
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
@@ -60,7 +52,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) error {
-	err := opts.client.WatchDelete(&metav1.ObjectMeta{
+	err := opts.Client().V1().KubeWatcher().Delete(&metav1.ObjectMeta{
 		Name:      opts.name,
 		Namespace: opts.namespace,
 	})

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -23,26 +23,18 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
-	client    *client.Client
+	cmd.CommandActioner
 	namespace string
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
@@ -59,7 +51,7 @@ func (opts *ListSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) error {
-	ws, err := opts.client.WatchList(opts.namespace)
+	ws, err := opts.Client().V1().KubeWatcher().List(opts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "error listing kubewatches")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -24,8 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -34,19 +34,12 @@ import (
 )
 
 type CreateSubCommand struct {
-	client  *client.Client
+	cmd.CommandActioner
 	trigger *fv1.MessageQueueTrigger
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -164,7 +157,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.client.MessageQueueTriggerCreate(opts.trigger)
+	_, err := opts.Client().V1().MessageQueueTrigger().Create(opts.trigger)
 	if err != nil {
 		return errors.Wrap(err, "create message queue trigger")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/delete.go
+++ b/pkg/fission-cli/cmd/mqtrigger/delete.go
@@ -22,26 +22,18 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
-	client   *client.Client
+	cmd.CommandActioner
 	metadata *metav1.ObjectMeta
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DeleteSubCommand{}).do(input)
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
@@ -61,7 +53,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) error {
-	err := opts.client.MessageQueueTriggerDelete(opts.metadata)
+	err := opts.Client().V1().MessageQueueTrigger().Delete(opts.metadata)
 	if err != nil {
 		return errors.Wrap(err, "error deleting message queue trigger")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -23,26 +23,18 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
-	client    *client.Client
+	cmd.CommandActioner
 	namespace string
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
@@ -59,7 +51,7 @@ func (opts *ListSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) error {
-	mqts, err := opts.client.MessageQueueTriggerList(input.String(flagkey.MqtMQType), opts.namespace)
+	mqts, err := opts.Client().V1().MessageQueueTrigger().List(input.String(flagkey.MqtMQType), opts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "error listing message queue triggers")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -23,26 +23,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
-	client  *client.Client
+	cmd.CommandActioner
 	trigger *fv1.MessageQueueTrigger
 }
 
 func Update(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := UpdateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&UpdateSubCommand{}).do(input)
 }
 
 func (opts *UpdateSubCommand) do(input cli.Input) error {
@@ -54,7 +46,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
-	mqt, err := opts.client.MessageQueueTriggerGet(&metav1.ObjectMeta{
+	mqt, err := opts.Client().V1().MessageQueueTrigger().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.MqtName),
 		Namespace: input.String(flagkey.NamespaceTrigger),
 	})
@@ -111,7 +103,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.client.MessageQueueTriggerUpdate(opts.trigger)
+	_, err := opts.Client().V1().MessageQueueTrigger().Update(opts.trigger)
 	if err != nil {
 		return errors.Wrap(err, "error updating message queue trigger")
 	}

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -30,6 +30,7 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
 	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -37,18 +38,11 @@ import (
 )
 
 type CreateSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -114,14 +108,14 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		specFile = fmt.Sprintf("package-%v.yaml", pkgName)
 	}
 
-	_, err := CreatePackage(input, opts.client, pkgName, pkgNamespace, envName, envNamespace,
+	_, err := CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName, envNamespace,
 		srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip)
 
 	return err
 }
 
 // TODO: get all necessary value from CLI input directly
-func CreatePackage(input cli.Input, client *client.Client, pkgName string, pkgNamespace string, envName string, envNamespace string,
+func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkgNamespace string, envName string, envNamespace string,
 	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, specDir string, specFile string, noZip bool) (*metav1.ObjectMeta, error) {
 
 	insecure := input.Bool(flagkey.PkgInsecure)
@@ -201,7 +195,7 @@ func CreatePackage(input cli.Input, client *client.Client, pkgName string, pkgNa
 		}
 		return &pkg.Metadata, nil
 	} else {
-		pkgMetadata, err := client.PackageCreate(pkg)
+		pkgMetadata, err := client.V1().Package().Create(pkg)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating package")
 		}

--- a/pkg/fission-cli/cmd/package/delete.go
+++ b/pkg/fission-cli/cmd/package/delete.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
-	client        *client.Client
+	cmd.CommandActioner
 	name          string
 	namespace     string
 	deleteOrphans bool
@@ -37,14 +37,7 @@ type DeleteSubCommand struct {
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DeleteSubCommand{}).do(input)
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
@@ -70,7 +63,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) run(input cli.Input) error {
 	if len(opts.name) != 0 {
-		_, err := opts.client.PackageGet(&metav1.ObjectMeta{
+		_, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
 			Namespace: opts.namespace,
 			Name:      opts.name,
 		})
@@ -78,7 +71,7 @@ func (opts *DeleteSubCommand) run(input cli.Input) error {
 			return errors.Wrap(err, "find package")
 		}
 
-		fnList, err := GetFunctionsByPackage(opts.client, opts.name, opts.namespace)
+		fnList, err := GetFunctionsByPackage(opts.Client(), opts.name, opts.namespace)
 		if err != nil {
 			return err
 		}
@@ -86,7 +79,7 @@ func (opts *DeleteSubCommand) run(input cli.Input) error {
 		if !opts.force && len(fnList) > 0 {
 			return errors.New("Package is used by at least one function, use -f to force delete")
 		}
-		err = deletePackage(opts.client, opts.name, opts.namespace)
+		err = deletePackage(opts.Client(), opts.name, opts.namespace)
 		if err != nil {
 			return err
 		}
@@ -95,7 +88,7 @@ func (opts *DeleteSubCommand) run(input cli.Input) error {
 
 	// TODO improve list speed when --orphan
 	if opts.deleteOrphans {
-		err := deleteOrphanPkgs(opts.client, opts.namespace)
+		err := deleteOrphanPkgs(opts.Client(), opts.namespace)
 		if err != nil {
 			return errors.Wrap(err, "deleting orphan packages")
 		}
@@ -105,8 +98,8 @@ func (opts *DeleteSubCommand) run(input cli.Input) error {
 	return nil
 }
 
-func deleteOrphanPkgs(client *client.Client, pkgNamespace string) error {
-	pkgList, err := client.PackageList(pkgNamespace)
+func deleteOrphanPkgs(client client.Interface, pkgNamespace string) error {
+	pkgList, err := client.V1().Package().List(pkgNamespace)
 	if err != nil {
 		return err
 	}
@@ -127,8 +120,8 @@ func deleteOrphanPkgs(client *client.Client, pkgNamespace string) error {
 	return nil
 }
 
-func deletePackage(client *client.Client, pkgName string, pkgNamespace string) error {
-	return client.PackageDelete(&metav1.ObjectMeta{
+func deletePackage(client client.Interface, pkgName string, pkgNamespace string) error {
+	return client.V1().Package().Delete(&metav1.ObjectMeta{
 		Namespace: pkgNamespace,
 		Name:      pkgName,
 	})

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -24,11 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 const (
@@ -37,7 +36,7 @@ const (
 )
 
 type GetSubCommand struct {
-	client      *client.Client
+	cmd.CommandActioner
 	name        string
 	namespace   string
 	output      string
@@ -45,27 +44,11 @@ type GetSubCommand struct {
 }
 
 func GetSrc(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := GetSubCommand{
-		client:      c,
-		archiveType: sourceArchive,
-	}
-	return opts.do(input)
+	return (&GetSubCommand{}).do(input)
 }
 
 func GetDeploy(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := GetSubCommand{
-		client:      c,
-		archiveType: deployArchive,
-	}
-	return opts.do(input)
+	return (&GetSubCommand{}).do(input)
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
@@ -84,7 +67,7 @@ func (opts *GetSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) run(input cli.Input) error {
-	pkg, err := opts.client.PackageGet(&metav1.ObjectMeta{
+	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
 		Namespace: opts.namespace,
 		Name:      opts.name,
 	})
@@ -101,7 +84,7 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 	if pkg.Spec.Deployment.Type == fv1.ArchiveTypeLiteral {
 		reader = bytes.NewReader(archive.Literal)
 	} else if pkg.Spec.Deployment.Type == fv1.ArchiveTypeUrl {
-		readCloser, err := pkgutil.DownloadStoragesvcURL(opts.client, archive.URL)
+		readCloser, err := pkgutil.DownloadStoragesvcURL(opts.Client(), archive.URL)
 		if err != nil {
 			return err
 		}

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -22,28 +22,20 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type InfoSubCommand struct {
-	client    *client.Client
+	cmd.CommandActioner
 	name      string
 	namespace string
 }
 
 func Info(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := InfoSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&InfoSubCommand{}).do(input)
 }
 
 func (opts *InfoSubCommand) do(input cli.Input) error {
@@ -61,7 +53,7 @@ func (opts *InfoSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *InfoSubCommand) run(input cli.Input) error {
-	pkg, err := opts.client.PackageGet(&metav1.ObjectMeta{
+	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
 		Namespace: opts.namespace,
 		Name:      opts.name,
 	})

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -25,28 +25,20 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
-	client       *client.Client
+	cmd.CommandActioner
 	listOrphans  bool
 	status       string
 	pkgNamespace string
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
@@ -66,7 +58,7 @@ func (opts *ListSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) error {
-	pkgList, err := opts.client.PackageList(opts.pkgNamespace)
+	pkgList, err := opts.Client().V1().Package().List(opts.pkgNamespace)
 	if err != nil {
 		return err
 	}
@@ -83,7 +75,7 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 		show := true
 		// TODO improve list speed when --orphan
 		if opts.listOrphans {
-			fnList, err := GetFunctionsByPackage(opts.client, pkg.Metadata.Name, pkg.Metadata.Namespace)
+			fnList, err := GetFunctionsByPackage(opts.Client(), pkg.Metadata.Name, pkg.Metadata.Namespace)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("get functions sharing package %s", pkg.Metadata.Name))
 			}

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -45,7 +45,7 @@ import (
 // create an archive upload spec in the specs directory; otherwise
 // upload the archive using client.  noZip avoids zipping the
 // includeFiles, but is ignored if there's more than one includeFile.
-func CreateArchive(client *client.Client, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string) (*fv1.Archive, error) {
+func CreateArchive(client client.Interface, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string) (*fv1.Archive, error) {
 	// get root dir
 	var rootDir string
 	var err error
@@ -241,8 +241,8 @@ func archiveName(givenNameHint string, includedFiles []string) string {
 	return fmt.Sprintf("%v-%v", util.KubifyName(includedFiles[0]), uniuri.NewLen(4))
 }
 
-func GetFunctionsByPackage(client *client.Client, pkgName, pkgNamespace string) ([]fv1.Function, error) {
-	fnList, err := client.FunctionList(pkgNamespace)
+func GetFunctionsByPackage(client client.Interface, pkgName, pkgNamespace string) ([]fv1.Function, error) {
+	fnList, err := client.V1().Function().List(pkgNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -23,27 +23,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type RebuildSubCommand struct {
-	client    *client.Client
+	cmd.CommandActioner
 	name      string
 	namespace string
 }
 
 func Rebuild(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := RebuildSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&RebuildSubCommand{}).do(input)
 }
 
 func (opts *RebuildSubCommand) do(input cli.Input) error {
@@ -61,7 +53,7 @@ func (opts *RebuildSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *RebuildSubCommand) run(input cli.Input) error {
-	pkg, err := opts.client.PackageGet(&metav1.ObjectMeta{
+	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
 		Name:      opts.name,
 		Namespace: opts.namespace,
 	})
@@ -74,7 +66,7 @@ func (opts *RebuildSubCommand) run(input cli.Input) error {
 			pkg.Metadata.Name, fv1.BuildStatusFailed))
 	}
 
-	_, err = updatePackageStatus(opts.client, pkg, fv1.BuildStatusPending)
+	_, err = updatePackageStatus(opts.Client(), pkg, fv1.BuildStatusPending)
 	if err != nil {
 		return errors.Wrap(err, "update package status")
 	}

--- a/pkg/fission-cli/cmd/plugin/list.go
+++ b/pkg/fission-cli/cmd/plugin/list.go
@@ -21,25 +21,17 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
-	"github.com/fission/fission/pkg/fission-cli/util"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/plugin"
 )
 
 type ListSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := &ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {

--- a/pkg/fission-cli/cmd/spec/buildwatch.go
+++ b/pkg/fission-cli/cmd/spec/buildwatch.go
@@ -34,7 +34,7 @@ type (
 	// packageBuildWatcher is used to watch a set of in-progress builds.
 	packageBuildWatcher struct {
 		// fission client
-		fclient *client.Client
+		fclient client.Interface
 
 		// set of packages already printed, ensures we don't duplicate the notifications
 		finished map[string]bool
@@ -44,7 +44,7 @@ type (
 	}
 )
 
-func makePackageBuildWatcher(fclient *client.Client) *packageBuildWatcher {
+func makePackageBuildWatcher(fclient client.Interface) *packageBuildWatcher {
 	return &packageBuildWatcher{
 		fclient:  fclient,
 		finished: make(map[string]bool),
@@ -68,7 +68,7 @@ func (w *packageBuildWatcher) watch(ctx context.Context) {
 		}
 
 		// pull list of packages (TODO: convert to watch)
-		pkgs, err := w.fclient.PackageList(metav1.NamespaceAll)
+		pkgs, err := w.fclient.V1().Package().List(metav1.NamespaceAll)
 		if err != nil {
 			fmt.Printf("Getting list of packages: %v", err)
 			os.Exit(1)

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -19,25 +19,18 @@ package spec
 import (
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DestroySubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 // Destroy destroys everything in the spec.
 func Destroy(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := &DestroySubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DestroySubCommand{}).do(input)
 }
 
 func (opts *DestroySubCommand) do(input cli.Input) error {
@@ -59,7 +52,7 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 	emptyFr.DeploymentConfig = fr.DeploymentConfig
 
 	// "apply" the empty state
-	_, _, err = applyResources(opts.client, specDir, &emptyFr, true)
+	_, _, err = applyResources(opts.Client(), specDir, &emptyFr, true)
 	if err != nil {
 		return errors.Wrap(err, "error deleting resources")
 	}

--- a/pkg/fission-cli/cmd/spec/init.go
+++ b/pkg/fission-cli/cmd/spec/init.go
@@ -26,27 +26,20 @@ import (
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	spectypes "github.com/fission/fission/pkg/fission-cli/cmd/spec/types"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type InitSubCommand struct {
-	client       *client.Client
+	cmd.CommandActioner
 	deployConfig *spectypes.DeploymentConfig
 }
 
 func Init(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := InitSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&InitSubCommand{}).do(input)
 }
 
 func (opts *InitSubCommand) do(input cli.Input) error {

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -378,7 +378,7 @@ func (fr *FissionResources) Validate(input cli.Input) error {
 			return err
 		}
 		for _, cm := range f.Spec.ConfigMaps {
-			_, err := client.ConfigMapGet(&metav1.ObjectMeta{
+			_, err := client.V1().Misc().ConfigMapGet(&metav1.ObjectMeta{
 				Name:      cm.Name,
 				Namespace: cm.Namespace,
 			})
@@ -388,7 +388,7 @@ func (fr *FissionResources) Validate(input cli.Input) error {
 		}
 
 		for _, s := range f.Spec.Secrets {
-			_, err := client.SecretGet(&metav1.ObjectMeta{
+			_, err := client.V1().Misc().SecretGet(&metav1.ObjectMeta{
 				Name:      s.Name,
 				Namespace: s.Namespace,
 			})

--- a/pkg/fission-cli/cmd/spec/validate.go
+++ b/pkg/fission-cli/cmd/spec/validate.go
@@ -27,26 +27,19 @@ import (
 	"github.com/pkg/errors"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ValidateSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 // Validate parses a set of specs and checks for references to
 // resources that don't exist.
 func Validate(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := &ValidateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ValidateSubCommand{}).do(input)
 }
 
 func (opts *ValidateSubCommand) do(input cli.Input) error {

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/support/resources"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
@@ -39,18 +39,11 @@ const (
 )
 
 type DumpSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Dump(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := &DumpSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DumpSubCommand{}).do(input)
 }
 
 func (opts *DumpSubCommand) do(input cli.Input) error {
@@ -86,7 +79,7 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"kubernetes-nodes":   resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesNode, ""),
 
 		// fission info
-		"fission-version": resources.NewFissionVersion(opts.client),
+		"fission-version": resources.NewFissionVersion(opts.Client()),
 
 		// fission component logs & spec
 		"fission-components-svc-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService,
@@ -113,13 +106,13 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "executorType in (poolmgr, newdeploy)"),
 
 		// CRD resources
-		"fission-crd-packages":     resources.NewCrdDumper(opts.client, resources.CrdPackage),
-		"fission-crd-environments": resources.NewCrdDumper(opts.client, resources.CrdEnvironment),
-		"fission-crd-functions":    resources.NewCrdDumper(opts.client, resources.CrdFunction),
-		"fission-crd-httptriggers": resources.NewCrdDumper(opts.client, resources.CrdHttpTrigger),
-		"fission-crd-kubewatchers": resources.NewCrdDumper(opts.client, resources.CrdKubeWatcher),
-		"fission-crd-mqtriggers":   resources.NewCrdDumper(opts.client, resources.CrdMessageQueueTrigger),
-		"fission-crd-timetriggers": resources.NewCrdDumper(opts.client, resources.CrdTimeTrigger),
+		"fission-crd-packages":     resources.NewCrdDumper(opts.Client(), resources.CrdPackage),
+		"fission-crd-environments": resources.NewCrdDumper(opts.Client(), resources.CrdEnvironment),
+		"fission-crd-functions":    resources.NewCrdDumper(opts.Client(), resources.CrdFunction),
+		"fission-crd-httptriggers": resources.NewCrdDumper(opts.Client(), resources.CrdHttpTrigger),
+		"fission-crd-kubewatchers": resources.NewCrdDumper(opts.Client(), resources.CrdKubeWatcher),
+		"fission-crd-mqtriggers":   resources.NewCrdDumper(opts.Client(), resources.CrdMessageQueueTrigger),
+		"fission-crd-timetriggers": resources.NewCrdDumper(opts.Client(), resources.CrdTimeTrigger),
 	}
 
 	dumpName := fmt.Sprintf("%v_%v", DUMP_ARCHIVE_PREFIX, time.Now().Unix())

--- a/pkg/fission-cli/cmd/support/resources/crd.go
+++ b/pkg/fission-cli/cmd/support/resources/crd.go
@@ -39,11 +39,11 @@ const (
 )
 
 type CrdDumper struct {
-	client  *client.Client
+	client  client.Interface
 	crdType string
 }
 
-func NewCrdDumper(client *client.Client, crdType string) Resource {
+func NewCrdDumper(client client.Interface, crdType string) Resource {
 	return CrdDumper{client: client, crdType: crdType}
 }
 
@@ -51,7 +51,7 @@ func (res CrdDumper) Dump(dumpDir string) {
 
 	switch res.crdType {
 	case CrdEnvironment:
-		items, err := res.client.EnvironmentList(metav1.NamespaceAll)
+		items, err := res.client.V1().Environment().List(metav1.NamespaceAll)
 		if err != nil {
 			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 			return
@@ -63,7 +63,7 @@ func (res CrdDumper) Dump(dumpDir string) {
 		}
 
 	case CrdFunction:
-		items, err := res.client.FunctionList(metav1.NamespaceAll)
+		items, err := res.client.V1().Function().List(metav1.NamespaceAll)
 		if err != nil {
 			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 			return
@@ -75,7 +75,7 @@ func (res CrdDumper) Dump(dumpDir string) {
 		}
 
 	case CrdPackage:
-		items, err := res.client.PackageList(metav1.NamespaceAll)
+		items, err := res.client.V1().Package().List(metav1.NamespaceAll)
 		if err != nil {
 			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 			return
@@ -88,7 +88,7 @@ func (res CrdDumper) Dump(dumpDir string) {
 		}
 
 	case CrdHttpTrigger:
-		items, err := res.client.HTTPTriggerList(metav1.NamespaceAll)
+		items, err := res.client.V1().HTTPTrigger().List(metav1.NamespaceAll)
 		if err != nil {
 			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 			return
@@ -100,7 +100,7 @@ func (res CrdDumper) Dump(dumpDir string) {
 		}
 
 	case CrdKubeWatcher:
-		items, err := res.client.WatchList(metav1.NamespaceAll)
+		items, err := res.client.V1().KubeWatcher().List(metav1.NamespaceAll)
 		if err != nil {
 			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 			return
@@ -115,7 +115,7 @@ func (res CrdDumper) Dump(dumpDir string) {
 		var triggers []fv1.MessageQueueTrigger
 
 		for _, mqType := range []string{types.MessageQueueTypeNats, types.MessageQueueTypeASQ} {
-			l, err := res.client.MessageQueueTriggerList(mqType, metav1.NamespaceAll)
+			l, err := res.client.V1().MessageQueueTrigger().List(mqType, metav1.NamespaceAll)
 			if err != nil {
 				console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 				break
@@ -129,7 +129,7 @@ func (res CrdDumper) Dump(dumpDir string) {
 		}
 
 	case CrdTimeTrigger:
-		items, err := res.client.TimeTriggerList(metav1.NamespaceAll)
+		items, err := res.client.V1().TimeTrigger().List(metav1.NamespaceAll)
 		if err != nil {
 			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 			return

--- a/pkg/fission-cli/cmd/support/resources/fissionversion.go
+++ b/pkg/fission-cli/cmd/support/resources/fissionversion.go
@@ -25,10 +25,10 @@ import (
 )
 
 type FissionVersion struct {
-	client *client.Client
+	client client.Interface
 }
 
-func NewFissionVersion(client *client.Client) Resource {
+func NewFissionVersion(client client.Interface) Resource {
 	return FissionVersion{client: client}
 }
 

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -18,6 +18,7 @@ package timetrigger
 
 import (
 	"fmt"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"time"
 
 	"github.com/pkg/errors"
@@ -35,19 +36,12 @@ import (
 )
 
 type CreateSubCommand struct {
-	client  *client.Client
+	cmd.CommandActioner
 	trigger *fv1.TimeTrigger
 }
 
 func Create(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := CreateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&CreateSubCommand{}).do(input)
 }
 
 func (opts *CreateSubCommand) do(input cli.Input) error {
@@ -126,14 +120,14 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.client.TimeTriggerCreate(opts.trigger)
+	_, err := opts.Client().V1().TimeTrigger().Create(opts.trigger)
 	if err != nil {
 		return errors.Wrap(err, "error creating Time trigger")
 	}
 
 	fmt.Printf("trigger '%v' created\n", opts.trigger.Metadata.Name)
 
-	t, err := getAPITimeInfo(opts.client)
+	t, err := getAPITimeInfo(opts.Client())
 	if err != nil {
 		return err
 	}
@@ -146,8 +140,8 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 	return nil
 }
 
-func getAPITimeInfo(client *client.Client) (time.Time, error) {
-	serverInfo, err := client.ServerInfo()
+func getAPITimeInfo(client client.Interface) (time.Time, error) {
+	serverInfo, err := client.V1().Misc().ServerInfo()
 	if err != nil {
 		return time.Time{}, errors.Errorf("Error syncing server time information: %v", err)
 	}

--- a/pkg/fission-cli/cmd/timetrigger/delete.go
+++ b/pkg/fission-cli/cmd/timetrigger/delete.go
@@ -22,25 +22,17 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Delete(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := DeleteSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&DeleteSubCommand{}).do(input)
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
@@ -49,7 +41,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 		Namespace: input.String(flagkey.NamespaceTrigger),
 	}
 
-	err := opts.client.TimeTriggerDelete(m)
+	err := opts.Client().V1().TimeTrigger().Delete(m)
 	if err != nil {
 		return errors.Wrap(err, "error deleting trigger")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -21,31 +21,24 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/fission/fission/pkg/controller/client"
-	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
-	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/pkg/errors"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 )
 
 type ListSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func List(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ListSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ListSubCommand{}).do(input)
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
 	ttNs := input.String(flagkey.NamespaceTrigger)
-	tts, err := opts.client.TimeTriggerList(ttNs)
+	tts, err := opts.Client().V1().TimeTrigger().List(ttNs)
 	if err != nil {
 		return errors.Wrap(err, "list Time triggers")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/test.go
+++ b/pkg/fission-cli/cmd/timetrigger/test.go
@@ -19,25 +19,17 @@ package timetrigger
 import (
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ShowSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Show(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := ShowSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&ShowSubCommand{}).do(input)
 }
 
 func (opts *ShowSubCommand) do(input cli.Input) error {
@@ -51,7 +43,7 @@ func (opts *ShowSubCommand) run(flaginput cli.Input) error {
 		return errors.New("need a cron spec like '0 30 * * * *', '@every 1h30m', or '@hourly'; use --cron")
 	}
 
-	t, err := getAPITimeInfo(opts.client)
+	t, err := getAPITimeInfo(opts.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -23,26 +23,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
-	client  *client.Client
+	cmd.CommandActioner
 	trigger *fv1.TimeTrigger
 }
 
 func Update(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := UpdateSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&UpdateSubCommand{}).do(input)
 }
 
 func (opts *UpdateSubCommand) do(input cli.Input) error {
@@ -54,7 +46,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
-	tt, err := opts.client.TimeTriggerGet(&metav1.ObjectMeta{
+	tt, err := opts.Client().V1().TimeTrigger().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.TtName),
 		Namespace: input.String(flagkey.NamespaceTrigger),
 	})
@@ -88,14 +80,14 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.client.TimeTriggerUpdate(opts.trigger)
+	_, err := opts.Client().V1().TimeTrigger().Update(opts.trigger)
 	if err != nil {
 		return errors.Wrap(err, "error updating Time trigger")
 	}
 
 	fmt.Printf("trigger '%v' updated\n", opts.trigger.Metadata.Name)
 
-	t, err := getAPITimeInfo(opts.client)
+	t, err := getAPITimeInfo(opts.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/version/version.go
+++ b/pkg/fission-cli/cmd/version/version.go
@@ -22,28 +22,21 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type VersionSubCommand struct {
-	client *client.Client
+	cmd.CommandActioner
 }
 
 func Version(input cli.Input) error {
-	c, err := util.GetServer(input)
-	if err != nil {
-		return err
-	}
-	opts := &VersionSubCommand{
-		client: c,
-	}
-	return opts.do(input)
+	return (&VersionSubCommand{}).do(input)
 }
 
 func (opts *VersionSubCommand) do(input cli.Input) error {
-	ver := util.GetVersion(opts.client)
+	ver := util.GetVersion(opts.Client())
 	bs, err := yaml.Marshal(ver)
 	if err != nil {
 		return errors.Wrap(err, "error formatting versions")

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/fission/fission/pkg/controller/client/rest"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -144,7 +145,7 @@ func GetKubernetesClient() (*restclient.Config, *kubernetes.Clientset, error) {
 }
 
 // given a list of functions, this checks if the functions actually exist on the cluster
-func CheckFunctionExistence(fissionClient *client.Client, functions []string, fnNamespace string) (err error) {
+func CheckFunctionExistence(client client.Interface, functions []string, fnNamespace string) (err error) {
 	fnMissing := make([]string, 0)
 	for _, fnName := range functions {
 		meta := &metav1.ObjectMeta{
@@ -152,7 +153,7 @@ func CheckFunctionExistence(fissionClient *client.Client, functions []string, fn
 			Namespace: fnNamespace,
 		}
 
-		_, err := fissionClient.FunctionGet(meta)
+		_, err := client.V1().Function().Get(meta)
 		if err != nil {
 			fnMissing = append(fnMissing, fnName)
 		}
@@ -165,7 +166,7 @@ func CheckFunctionExistence(fissionClient *client.Client, functions []string, fn
 	return nil
 }
 
-func GetVersion(client *client.Client) info.Versions {
+func GetVersion(client client.Interface) info.Versions {
 	// Fetch client versions
 	versions := info.Versions{
 		Client: map[string]info.BuildMeta{
@@ -179,7 +180,7 @@ func GetVersion(client *client.Client) info.Versions {
 		}
 	}
 
-	serverInfo, err := client.ServerInfo()
+	serverInfo, err := client.V1().Misc().ServerInfo()
 	if err != nil {
 		console.Warn(fmt.Sprintf("Error getting Fission API version: %v", err))
 		serverInfo = &info.ServerInfo{}
@@ -195,13 +196,21 @@ func GetVersion(client *client.Client) info.Versions {
 	return versions
 }
 
-func GetServer(input cli.Input) (c *client.Client, err error) {
-	serverUrl := input.GlobalString(flagkey.Server)
+func GetServer(input cli.Input) (c client.Interface, err error) {
+	serverUrl, err := GetServerURL(input)
+	if err != nil {
+		return nil, err
+	}
+	return client.MakeClientset(rest.NewRESTClient(serverUrl)), nil
+}
+
+func GetServerURL(input cli.Input) (serverUrl string, err error) {
+	serverUrl = input.GlobalString(flagkey.Server)
 	if len(serverUrl) == 0 {
 		// starts local portforwarder etc.
 		serverUrl, err = GetApplicationUrl("application=fission-api")
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 	}
 
@@ -212,7 +221,7 @@ func GetServer(input cli.Input) (c *client.Client, err error) {
 		serverUrl = "http://" + serverUrl
 	}
 
-	return client.MakeClient(serverUrl), nil
+	return serverUrl, nil
 }
 
 func GetResourceReqs(input cli.Input, resReqs *v1.ResourceRequirements) (*v1.ResourceRequirements, error) {


### PR DESCRIPTION
This PR adds an interface for controller API client, it allows us to
implement mock API client for unit testing with ease and we are
able to generate spec file without accessing the real Fission server.